### PR TITLE
Deployment "caching".

### DIFF
--- a/spring/spring-hibernate/pom.xml
+++ b/spring/spring-hibernate/pom.xml
@@ -67,11 +67,6 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-service-deployer-spring-3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-service-integration-spring-inject</artifactId>
             <scope>test</scope>
         </dependency>

--- a/spring/spring-hibernate/src/test/java/com/acme/spring/hibernate/Deployments.java
+++ b/spring/spring-hibernate/src/test/java/com/acme/spring/hibernate/Deployments.java
@@ -27,9 +27,6 @@ import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
 import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * <p>A helper class for creating the tests deployments.</p>
@@ -37,6 +34,11 @@ import java.util.List;
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
 public final class Deployments {
+
+    /**
+     * <p>Represents the deployment dependencies.</p>
+     */
+    private static File[] deploymentsDependencies;
 
     /**
      * <p>Creates new instance of {@link Deployments} class.</p>
@@ -64,40 +66,27 @@ public final class Deployments {
                 .addAsResource("create.sql")
                 .addAsResource("delete.sql")
                 .addAsResource("insert.sql")
-                .addAsLibraries(springDependencies());
+                .addAsLibraries(getDeploymentDependencies());
     }
 
     /**
-     * <p>Retrieves the dependencies.</p>
+     * <p>Retrieves the deployment dependencies.</p>
      *
-     * @return the array of the dependencies
+     * @return the deployment dependencies
      */
-    public static File[] springDependencies() {
+    private static File[] getDeploymentDependencies() {
 
-        ArrayList<File> files = new ArrayList<File>();
+        if (deploymentsDependencies == null) {
 
-        files.addAll(resolveDependencies("org.springframework:spring-context:3.1.1.RELEASE"));
-        files.addAll(resolveDependencies("org.springframework:spring-orm:3.1.1.RELEASE"));
-        files.addAll(resolveDependencies("org.springframework:spring-tx:3.1.1.RELEASE"));
-        files.addAll(resolveDependencies("org.hibernate:hibernate-core:3.6.0.Final"));
-        files.addAll(resolveDependencies("org.hibernate:hibernate-annotations:3.4.0.GA"));
-        files.addAll(resolveDependencies("javassist:javassist:3.6.0.GA"));
+            deploymentsDependencies = DependencyResolvers.use(MavenDependencyResolver.class)
+                    .artifacts("org.springframework:spring-context:3.1.1.RELEASE",
+                            "org.springframework:spring-orm:3.1.1.RELEASE",
+                            "org.springframework:spring-tx:3.1.1.RELEASE",
+                            "org.hibernate:hibernate-core:3.6.0.Final",
+                            "javassist:javassist:3.6.0.GA")
+                    .resolveAsFiles();
+        }
 
-        return files.toArray(new File[files.size()]);
-    }
-
-    /**
-     * <p>Resolves the given artifact by it's name with help of maven build system.</p>
-     *
-     * @param artifactName the fully qualified artifact name
-     *
-     * @return the resolved files
-     */
-    public static List<File> resolveDependencies(String artifactName) {
-        MavenDependencyResolver mvnResolver = DependencyResolvers.use(MavenDependencyResolver.class);
-
-        mvnResolver.loadMetadataFromPom("pom.xml");
-
-        return Arrays.asList(mvnResolver.artifacts(artifactName).resolveAsFiles());
+        return deploymentsDependencies;
     }
 }

--- a/spring/spring-hibernate/src/test/resources/arquillian.xml
+++ b/spring/spring-hibernate/src/test/resources/arquillian.xml
@@ -7,6 +7,10 @@
 
     <defaultProtocol type="Servlet 3.0"/>
 
+    <engine>
+        <property name="deploymentExportPath">target/test-archives</property>
+    </engine>
+
     <!-- Managed container settings -->
     <container qualifier="jbossas-managed" default="true">
         <configuration>
@@ -14,11 +18,5 @@
             <property name="outputToConsole">true</property>
         </configuration>
     </container>
-
-    <!-- Spring extension settings -->
-    <extension qualifier="spring-deployer">
-        <!-- Disables the auto package allowing to add all the dependencies through the test -->
-        <property name="autoPackage">false</property>
-    </extension>
 
 </arquillian>

--- a/spring/spring-inject/pom.xml
+++ b/spring/spring-inject/pom.xml
@@ -42,11 +42,6 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-service-deployer-spring-3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-service-integration-spring-inject</artifactId>
             <scope>test</scope>
         </dependency>

--- a/spring/spring-inject/src/test/java/com/acme/spring/inject/Deployments.java
+++ b/spring/spring-inject/src/test/java/com/acme/spring/inject/Deployments.java
@@ -22,7 +22,11 @@ import com.acme.spring.inject.repository.impl.DefaultStockRepository;
 import com.acme.spring.inject.service.StockService;
 import com.acme.spring.inject.service.impl.DefaultStockService;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
+
+import java.io.File;
 
 /**
  * <p>A helper class for creating the tests deployments.</p>
@@ -30,6 +34,11 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
 public final class Deployments {
+
+    /**
+     * <p>Represents the deployment dependencies.</p>
+     */
+    private static File[] deploymentsDependencies;
 
     /**
      * <p>Creates new instance of {@link com.acme.spring.inject.Deployments} class.</p>
@@ -41,13 +50,33 @@ public final class Deployments {
     }
 
     /**
-     * <p>Creates new tests deployment</p>
+     * <p>Creates new test deployment.</p>
+     *
+     * @return new test deployment
      */
-    public static JavaArchive createDeployment() {
+    public static WebArchive createDeployment() {
 
-        return ShrinkWrap.create(JavaArchive.class, "spring-test.jar")
+        return ShrinkWrap.create(WebArchive.class, "spring-test.war")
                 .addClasses(Stock.class, StockRepository.class, StockService.class,
                         DefaultStockRepository.class, DefaultStockService.class)
-                .addAsResource("applicationContext.xml");
+                .addAsResource("applicationContext.xml")
+                .addAsLibraries(getDeploymentDependencies());
+    }
+
+    /**
+     * <p>Retrieves the deployment dependencies.</p>
+     *
+     * @return the deployment dependencies
+     */
+    private static File[] getDeploymentDependencies() {
+
+        if (deploymentsDependencies == null) {
+
+            deploymentsDependencies = DependencyResolvers.use(MavenDependencyResolver.class)
+                    .artifacts("org.springframework:spring-context:3.1.1.RELEASE")
+                    .resolveAsFiles();
+        }
+
+        return deploymentsDependencies;
     }
 }

--- a/spring/spring-javaconfig/pom.xml
+++ b/spring/spring-javaconfig/pom.xml
@@ -42,11 +42,6 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-service-deployer-spring-3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-service-integration-spring-javaconfig</artifactId>
             <scope>test</scope>
         </dependency>

--- a/spring/spring-javaconfig/src/test/java/com/acme/spring/javaconfig/Deployments.java
+++ b/spring/spring-javaconfig/src/test/java/com/acme/spring/javaconfig/Deployments.java
@@ -23,7 +23,11 @@ import com.acme.spring.javaconfig.repository.impl.DefaultStockRepository;
 import com.acme.spring.javaconfig.service.StockService;
 import com.acme.spring.javaconfig.service.impl.DefaultStockService;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
+
+import java.io.File;
 
 /**
  * <p>A helper class for creating the tests deployments.</p>
@@ -31,6 +35,11 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
 public final class Deployments {
+
+    /**
+     * <p>Represents the deployment dependencies.</p>
+     */
+    private static File[] deploymentsDependencies;
 
     /**
      * <p>Creates new instance of {@link Deployments} class.</p>
@@ -42,12 +51,34 @@ public final class Deployments {
     }
 
     /**
-     * <p>Creates new tests deployment</p>
+     * <p>Creates new test deployment.</p>
+     *
+     * @return new test deployment
      */
-    public static JavaArchive createDeployment() {
+    public static WebArchive createDeployment() {
 
-        return ShrinkWrap.create(JavaArchive.class, "spring-test.jar")
+        return ShrinkWrap.create(WebArchive.class, "spring-test.war")
                 .addClasses(Stock.class, StockRepository.class, StockService.class,
-                        DefaultStockRepository.class, DefaultStockService.class, StockConfig.class);
+                        DefaultStockRepository.class, DefaultStockService.class, StockConfig.class)
+                .addAsLibraries(getDeploymentDependencies());
+    }
+
+    /**
+     * <p>Retrieves the deployment dependencies.</p>
+     *
+     * @return the deployment dependencies
+     */
+    private static File[] getDeploymentDependencies() {
+
+        if (deploymentsDependencies == null) {
+
+            deploymentsDependencies = DependencyResolvers.use(MavenDependencyResolver.class)
+                    .artifacts("org.springframework:spring-context:3.1.1.RELEASE", "cglib:cglib:2.2.2")
+                    .resolveAsFiles();
+
+
+        }
+
+        return deploymentsDependencies;
     }
 }

--- a/spring/spring-jdbc/pom.xml
+++ b/spring/spring-jdbc/pom.xml
@@ -52,11 +52,6 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-service-deployer-spring-3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-service-integration-spring-inject</artifactId>
             <scope>test</scope>
         </dependency>

--- a/spring/spring-jdbc/src/test/java/com/acme/spring/jdbc/Deployments.java
+++ b/spring/spring-jdbc/src/test/java/com/acme/spring/jdbc/Deployments.java
@@ -27,9 +27,6 @@ import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
 import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * <p>A helper class for creating the tests deployments.</p>
@@ -37,6 +34,11 @@ import java.util.List;
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
 public final class Deployments {
+
+    /**
+     * <p>Represents the deployment dependencies.</p>
+     */
+    private static File[] deploymentsDependencies;
 
     /**
      * <p>Creates new instance of {@link Deployments} class.</p>
@@ -48,9 +50,9 @@ public final class Deployments {
     }
 
     /**
-     * <p>Creates new tests deployment.</p>
+     * <p>Creates new test deployment.</p>
      *
-     * @return the create archive
+     * @return new test deployment
      */
     public static WebArchive createDeployment() {
 
@@ -64,37 +66,24 @@ public final class Deployments {
                 .addAsResource("create.sql")
                 .addAsResource("delete.sql")
                 .addAsResource("insert.sql")
-                .addAsLibraries(springDependencies());
+                .addAsLibraries(getDeploymentDependencies());
     }
 
     /**
-     * <p>Retrieves the dependencies.</p>
+     * <p>Retrieves the deployment dependencies.</p>
      *
-     * @return the array of the dependencies
+     * @return the deployment dependencies
      */
-    public static File[] springDependencies() {
+    private static File[] getDeploymentDependencies() {
 
-        ArrayList<File> files = new ArrayList<File>();
+        if (deploymentsDependencies == null) {
 
-        files.addAll(resolveDependencies("org.springframework:spring-context:3.1.1.RELEASE"));
-        files.addAll(resolveDependencies("org.springframework:spring-jdbc:3.1.1.RELEASE"));
-        files.addAll(resolveDependencies("org.springframework:spring-tx:3.1.1.RELEASE"));
+            deploymentsDependencies = DependencyResolvers.use(MavenDependencyResolver.class)
+                    .artifacts("org.springframework:spring-context:3.1.1.RELEASE",
+                            "org.springframework:spring-jdbc:3.1.1.RELEASE",
+                            "org.springframework:spring-tx:3.1.1.RELEASE").resolveAsFiles();
+        }
 
-        return files.toArray(new File[files.size()]);
-    }
-
-    /**
-     * <p>Resolves the given artifact by it's name with help of maven build system.</p>
-     *
-     * @param artifactName the fully qualified artifact name
-     *
-     * @return the resolved files
-     */
-    public static List<File> resolveDependencies(String artifactName) {
-        MavenDependencyResolver mvnResolver = DependencyResolvers.use(MavenDependencyResolver.class);
-
-        mvnResolver.loadMetadataFromPom("pom.xml");
-
-        return Arrays.asList(mvnResolver.artifacts(artifactName).resolveAsFiles());
+        return deploymentsDependencies;
     }
 }

--- a/spring/spring-jdbc/src/test/resources/arquillian.xml
+++ b/spring/spring-jdbc/src/test/resources/arquillian.xml
@@ -15,10 +15,4 @@
         </configuration>
     </container>
 
-    <!-- Spring extension settings -->
-    <extension qualifier="spring-deployer">
-        <!-- Disables the auto package allowing to add all the dependencies through the test -->
-        <property name="autoPackage">false</property>
-    </extension>
-
 </arquillian>

--- a/spring/spring-jms/pom.xml
+++ b/spring/spring-jms/pom.xml
@@ -47,11 +47,6 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-service-deployer-spring-3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-service-integration-spring-inject</artifactId>
             <scope>test</scope>
         </dependency>

--- a/spring/spring-jms/src/test/java/com/acme/spring/jms/Deployments.java
+++ b/spring/spring-jms/src/test/java/com/acme/spring/jms/Deployments.java
@@ -23,9 +23,6 @@ import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
 import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * <p>A helper class for creating the tests deployments.</p>
@@ -33,6 +30,11 @@ import java.util.List;
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
 public final class Deployments {
+
+    /**
+     * <p>Represents the deployment dependencies.</p>
+     */
+    private static File[] deploymentsDependencies;
 
     /**
      * <p>Creates new instance of {@link Deployments} class.</p>
@@ -44,7 +46,9 @@ public final class Deployments {
     }
 
     /**
-     * <p>Creates new tests deployment</p>
+     * <p>Creates new test deployment.</p>
+     *
+     * @return new test deployment
      */
     public static WebArchive createDeployment() {
 
@@ -52,36 +56,24 @@ public final class Deployments {
                 .addClasses(MessageSender.class, MessageSenderImpl.class)
                 .addAsWebInfResource("jboss-jms.xml")
                 .addAsResource("applicationContext.xml")
-                .addAsLibraries(springDependencies());
+                .addAsLibraries(getDeploymentDependencies());
     }
 
     /**
-     * <p>Retrieves the dependencies.</p>
+     * <p>Retrieves the deployment dependencies.</p>
      *
-     * @return the array of the dependencies
+     * @return the deployment dependencies
      */
-    public static File[] springDependencies() {
+    private static File[] getDeploymentDependencies() {
 
-        ArrayList<File> files = new ArrayList<File>();
+        if (deploymentsDependencies == null) {
 
-        files.addAll(resolveDependencies("org.springframework:spring-context:3.1.1.RELEASE"));
-        files.addAll(resolveDependencies("org.springframework:spring-jms:3.1.1.RELEASE"));
+            deploymentsDependencies = DependencyResolvers.use(MavenDependencyResolver.class)
+                    .artifacts("org.springframework:spring-context:3.1.1.RELEASE",
+                            "org.springframework:spring-jms:3.1.1.RELEASE")
+                    .resolveAsFiles();
+        }
 
-        return files.toArray(new File[files.size()]);
-    }
-
-    /**
-     * <p>Resolves the given artifact by it's name with help of maven build system.</p>
-     *
-     * @param artifactName the fully qualified artifact name
-     *
-     * @return the resolved files
-     */
-    public static List<File> resolveDependencies(String artifactName) {
-        MavenDependencyResolver mvnResolver = DependencyResolvers.use(MavenDependencyResolver.class);
-
-        mvnResolver.loadMetadataFromPom("pom.xml");
-
-        return Arrays.asList(mvnResolver.artifacts(artifactName).resolveAsFiles());
+        return deploymentsDependencies;
     }
 }

--- a/spring/spring-jms/src/test/resources/arquillian.xml
+++ b/spring/spring-jms/src/test/resources/arquillian.xml
@@ -16,10 +16,4 @@
         </configuration>
     </container>
 
-    <!-- Spring extension settings -->
-    <extension qualifier="spring-deployer">
-        <!-- Disables the auto package allowing to add all the dependencies through the test -->
-        <property name="autoPackage">false</property>
-    </extension>
-
 </arquillian>

--- a/spring/spring-jpa/pom.xml
+++ b/spring/spring-jpa/pom.xml
@@ -72,11 +72,6 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-service-deployer-spring-3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-service-integration-spring-inject</artifactId>
             <scope>test</scope>
         </dependency>

--- a/spring/spring-jpa/src/test/java/com/acme/spring/jpa/Deployments.java
+++ b/spring/spring-jpa/src/test/java/com/acme/spring/jpa/Deployments.java
@@ -27,9 +27,6 @@ import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
 import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * <p>A helper class for creating the tests deployments.</p>
@@ -37,6 +34,11 @@ import java.util.List;
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
 public final class Deployments {
+
+    /**
+     * <p>Represents the deployment dependencies.</p>
+     */
+    private static File[] deploymentsDependencies;
 
     /**
      * <p>Creates new instance of {@link Deployments} class.</p>
@@ -48,9 +50,9 @@ public final class Deployments {
     }
 
     /**
-     * <p>Creates new tests deployment.</p>
+     * <p>Creates new test deployment.</p>
      *
-     * @return the create archive
+     * @return new test deployment
      */
     public static WebArchive createDeployment() {
 
@@ -66,37 +68,25 @@ public final class Deployments {
                 .addAsResource("create.sql")
                 .addAsResource("delete.sql")
                 .addAsResource("insert.sql")
-                .addAsLibraries(springDependencies());
+                .addAsLibraries(getDeploymentDependencies());
     }
 
     /**
-     * <p>Retrieves the dependencies.</p>
+     * <p>Retrieves the deployment dependencies.</p>
      *
-     * @return the array of the dependencies
+     * @return the deployment dependencies
      */
-    public static File[] springDependencies() {
+    private static File[] getDeploymentDependencies() {
 
-        ArrayList<File> files = new ArrayList<File>();
+        if (deploymentsDependencies == null) {
 
-        files.addAll(resolveDependencies("org.springframework:spring-context:3.1.1.RELEASE"));
-        files.addAll(resolveDependencies("org.springframework:spring-orm:3.1.1.RELEASE"));
-        files.addAll(resolveDependencies("org.springframework:spring-tx:3.1.1.RELEASE"));
+            deploymentsDependencies = DependencyResolvers.use(MavenDependencyResolver.class)
+                    .artifacts("org.springframework:spring-context:3.1.1.RELEASE",
+                            "org.springframework:spring-orm:3.1.1.RELEASE",
+                            "org.springframework:spring-tx:3.1.1.RELEASE")
+                    .resolveAsFiles();
+        }
 
-        return files.toArray(new File[files.size()]);
-    }
-
-    /**
-     * <p>Resolves the given artifact by it's name with help of maven build system.</p>
-     *
-     * @param artifactName the fully qualified artifact name
-     *
-     * @return the resolved files
-     */
-    public static List<File> resolveDependencies(String artifactName) {
-        MavenDependencyResolver mvnResolver = DependencyResolvers.use(MavenDependencyResolver.class);
-
-        mvnResolver.loadMetadataFromPom("pom.xml");
-
-        return Arrays.asList(mvnResolver.artifacts(artifactName).resolveAsFiles());
+        return deploymentsDependencies;
     }
 }

--- a/spring/spring-jpa/src/test/resources/arquillian.xml
+++ b/spring/spring-jpa/src/test/resources/arquillian.xml
@@ -15,10 +15,4 @@
         </configuration>
     </container>
 
-    <!-- Spring extension settings -->
-    <extension qualifier="spring-deployer">
-        <!-- Disables the auto package allowing to add all the dependencies through the test -->
-        <property name="autoPackage">false</property>
-    </extension>
-
 </arquillian>

--- a/spring/spring-jsr330/pom.xml
+++ b/spring/spring-jsr330/pom.xml
@@ -42,11 +42,6 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-service-deployer-spring-3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-service-integration-spring-inject</artifactId>
             <scope>test</scope>
         </dependency>

--- a/spring/spring-jsr330/src/test/java/com/acme/spring/jsr330/Deployments.java
+++ b/spring/spring-jsr330/src/test/java/com/acme/spring/jsr330/Deployments.java
@@ -22,7 +22,11 @@ import com.acme.spring.jsr330.repository.impl.DefaultStockRepository;
 import com.acme.spring.jsr330.service.StockService;
 import com.acme.spring.jsr330.service.impl.DefaultStockService;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
+
+import java.io.File;
 
 /**
  * <p>A helper class for creating the tests deployments.</p>
@@ -30,6 +34,11 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
 public final class Deployments {
+
+    /**
+     * <p>Represents the deployment dependencies.</p>
+     */
+    private static File[] deploymentsDependencies;
 
     /**
      * <p>Creates new instance of {@link Deployments} class.</p>
@@ -41,13 +50,33 @@ public final class Deployments {
     }
 
     /**
-     * <p>Creates new tests deployment</p>
+     * <p>Creates new test deployment.</p>
+     *
+     * @return new test deployment
      */
-    public static JavaArchive createDeployment() {
+    public static WebArchive createDeployment() {
 
-        return ShrinkWrap.create(JavaArchive.class, "spring-test.jar")
+        return ShrinkWrap.create(WebArchive.class, "spring-test.war")
                 .addClasses(Stock.class, StockRepository.class, StockService.class,
                         DefaultStockRepository.class, DefaultStockService.class)
-                .addAsResource("applicationContext.xml");
+                .addAsResource("applicationContext.xml")
+                .addAsLibraries(getDeploymentDependencies());
+    }
+
+    /**
+     * <p>Retrieves the deployment dependencies.</p>
+     *
+     * @return the deployment dependencies
+     */
+    private static File[] getDeploymentDependencies() {
+
+        if (deploymentsDependencies == null) {
+
+            deploymentsDependencies = DependencyResolvers.use(MavenDependencyResolver.class)
+                    .artifacts("org.springframework:spring-context:3.1.1.RELEASE")
+                    .resolveAsFiles();
+        }
+
+        return deploymentsDependencies;
     }
 }

--- a/spring/spring-testng/pom.xml
+++ b/spring/spring-testng/pom.xml
@@ -42,11 +42,6 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
-            <artifactId>arquillian-service-deployer-spring-3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-service-integration-spring-inject</artifactId>
             <scope>test</scope>
         </dependency>

--- a/spring/spring-testng/src/test/java/com/acme/spring/testng/Deployments.java
+++ b/spring/spring-testng/src/test/java/com/acme/spring/testng/Deployments.java
@@ -22,7 +22,11 @@ import com.acme.spring.testng.repository.impl.DefaultStockRepository;
 import com.acme.spring.testng.service.StockService;
 import com.acme.spring.testng.service.impl.DefaultStockService;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.DependencyResolvers;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenDependencyResolver;
+
+import java.io.File;
 
 /**
  * <p>A helper class for creating the tests deployments.</p>
@@ -30,6 +34,11 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  * @author <a href="mailto:jmnarloch@gmail.com">Jakub Narloch</a>
  */
 public final class Deployments {
+
+    /**
+     * <p>Represents the deployment dependencies.</p>
+     */
+    private static File[] deploymentsDependencies;
 
     /**
      * <p>Creates new instance of {@link Deployments} class.</p>
@@ -41,13 +50,33 @@ public final class Deployments {
     }
 
     /**
-     * <p>Creates new tests deployment</p>
+     * <p>Creates new test deployment.</p>
+     *
+     * @return new test deployment
      */
-    public static JavaArchive createDeployment() {
+    public static WebArchive createDeployment() {
 
-        return ShrinkWrap.create(JavaArchive.class, "spring-test.jar")
+        return ShrinkWrap.create(WebArchive.class, "spring-test.war")
                 .addClasses(Stock.class, StockRepository.class, StockService.class,
                         DefaultStockRepository.class, DefaultStockService.class)
-                .addAsResource("applicationContext.xml");
+                .addAsResource("applicationContext.xml")
+                .addAsLibraries(getDeploymentDependencies());
+    }
+
+    /**
+     * <p>Retrieves the deployment dependencies.</p>
+     *
+     * @return the deployment dependencies
+     */
+    private static File[] getDeploymentDependencies() {
+
+        if (deploymentsDependencies == null) {
+
+            deploymentsDependencies = DependencyResolvers.use(MavenDependencyResolver.class)
+                    .artifacts("org.springframework:spring-context:3.1.1.RELEASE")
+                    .resolveAsFiles();
+        }
+
+        return deploymentsDependencies;
     }
 }


### PR DESCRIPTION
I tried to experiment with improving the test execution time. Basicly my idea here was to share the resolved libraries with all deployments. This give my a bit of improvment, but we will probably can see on the build server if that really works.

BTW. if you analyze the execution of the modules you could see partial execution times looking similar to the fallowing (this one is took from spring-hibernate):

> 21:14:28,256 INFO  [org.jboss.as](Controller Boot Thread) JBAS015874: JBoss AS 7.1.1.Final "Brontes" started in 5768ms - Started 133 of 208 services (74 services are passive or on-demand)
> 
> Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 18.822 sec
> 
> Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.447 sec
> 
> Total time: 51.415s

When to sum it up the test execution together with jboss start takes something around 32,058 s. I guess that the remaining time is realated to jboss unpacking in the target directory.
