### PR TITLE
added initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+    # specifying other dists doesn't make sense because `trusty` doesn't have `oraclejdk8` (fails due to `Sorry, but JDK '[oraclejdk8]' is not known.`) which is the only supported JDK currently. Testing on Mac OSX doesn't make too much sense since it will run the same `maven` based build routine.
+
+jdk:
+- oraclejdk8
+    # `openjdk8` not available
+- openjdk7
+- oraclejdk7
+
+install: /bin/true
+
+script:
+- mvn install -DskipTests=true -Dmaven.javadoc.skip=true --batch-mode --show-version
+    # add --update-snapshots if snapshots are used
+- mvn test verify --batch-mode


### PR DESCRIPTION
#### Short description of what this resolves:
Adds support for automatic tests on the free Travis CI service (free as in beer, no as in speech) which [already reveals build and test failures](https://travis-ci.org/krichter722/arquillian-showcase), so this should be useful.

#### Changes proposed in this pull request:

- adding the control file `.travis.yml`