### PR TITLE
added missing log4j.xml files

### DIFF
--- a/jpa/src/main/resources/log4j.xml
+++ b/jpa/src/main/resources/log4j.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration debug="false"
+    xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+              value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+        </layout>
+    </appender>
+
+    <root>
+        <level value="DEBUG" />
+        <appender-ref ref="console" />
+    </root>
+</log4j:configuration>

--- a/jsf/src/main/resources/log4j.xml
+++ b/jsf/src/main/resources/log4j.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration debug="false"
+    xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+              value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+        </layout>
+    </appender>
+
+    <root>
+        <level value="DEBUG" />
+        <appender-ref ref="console" />
+    </root>
+</log4j:configuration>


### PR DESCRIPTION
Added missing `log4j.xml` files in order to avoid messages in the form of `log4j:WARN No appenders could be found for logger [...]`.

#### Short description of what this resolves:
Missing `log4j.xml` cause messages `log4j:WARN No appenders could be found for logger [...]` and prevents output from being logged.

#### Changes proposed in this pull request:

- added `log4j.xml` files
